### PR TITLE
Hotfix to change .function() -> .apply()

### DIFF
--- a/evaltools/scoring/scores.py
+++ b/evaltools/scoring/scores.py
@@ -47,7 +47,7 @@ def summarize(part: Partition, scores: Iterable[Score]) -> Dict[str, ScoreValue]
     """
     summary = {}
     for score in scores:
-        summary[score.name] = score.function(part)
+        summary[score.name] = score.apply(part)
     return summary
 
 def summarize_many(parts: Iterable[Partition], scores: Iterable[Score], plan_names: List[str] = [],


### PR DESCRIPTION
We had changed our `Score` class to have an `apply` attribute (rather than a `function` attribute), but need to pull through our changes to the `summarize()` function as well as in our example notebooks.