### PR TITLE
add simp. EG and change competitive districts

### DIFF
--- a/docs/data/acs.html
+++ b/docs/data/acs.html
@@ -31,9 +31,9 @@
 import censusdata
 from pathlib import Path
 
-def cvap(state, geometry=&#34;tract&#34;) -&gt; pd.DataFrame:
+def cvap(state, geometry=&#34;tract&#34;, year=2019) -&gt; pd.DataFrame:
     &#34;&#34;&#34;
-    Retrieves and CSV-formats 2019 5-year CVAP data for the provided state at
+    Retrieves and CSV-formats 5-year CVAP data for the provided state at
     the specified geometry level. Geometries from the **2010 Census**. Variables
     and descriptions are [listed here](https://tinyurl.com/3mnrm56s&gt;).
 
@@ -43,10 +43,11 @@ def cvap(state, geometry=&#34;tract&#34;) -&gt; pd.DataFrame:
         geometry (str, optional): Level of geometry for which we&#39;re getting data.
             Accepted values are `&#34;block group&#34;` for 2010 Census Block Groups, and
             `&#34;tract&#34;` for 2010 Census Tracts. Defaults to `&#34;tract&#34;`.
+        year (int, optional): Year for which data is retrieved. Defaults to 2019.
 
     Returns
         A `DataFrame` with a `GEOID` column and corresponding CVAP columns from
-        the 2019 ACS CVAP Special Tab.
+        the ACS CVAP Special Tab for the specified year.
     &#34;&#34;&#34;
     # Maps line numbers to descriptors.
     descriptions = {
@@ -71,8 +72,9 @@ def cvap(state, geometry=&#34;tract&#34;) -&gt; pd.DataFrame:
         print(f&#34;Requested geometry \&#34;{geometry}\&#34; is not allowed; loading tracts.&#34;)
         geometry = &#34;tract&#34;
 
+    yearsuffix = str(year)[-2:]
     # Load the raw data.
-    raw = _raw(geometry)
+    raw = _raw(geometry, yearsuffix)
 
     # Create a STATE column for filtering and remove all rows which don&#39;t match
     # the state FIPS code.
@@ -99,15 +101,15 @@ def cvap(state, geometry=&#34;tract&#34;) -&gt; pd.DataFrame:
         block = instate_records[i:i+13]
         for line in block:
             record[geometry.replace(&#34; &#34;, &#34;&#34;).upper() + &#34;10&#34;] = line[&#34;GEOID&#34;]
-            record[descriptions[line[&#34;lnnumber&#34;]] + &#34;19&#34;] = line[&#34;cvap_est&#34;]
-            record[descriptions[line[&#34;lnnumber&#34;]] + &#34;19e&#34;] = line[&#34;cvap_moe&#34;]
+            record[descriptions[line[&#34;lnnumber&#34;]] + yearsuffix] = line[&#34;cvap_est&#34;]
+            record[descriptions[line[&#34;lnnumber&#34;]] + f&#34;{yearsuffix}e&#34;] = line[&#34;cvap_moe&#34;]
 
         collapsed.append(record)
 
     # Create a dataframe and a POCCVAP column; all people minus non-Hispanic
     # White.
     data = pd.DataFrame().from_records(collapsed)
-    data[&#34;POCCVAP19&#34;] = data[&#34;CVAP19&#34;] - data[&#34;NHWCVAP19&#34;]
+    data[f&#34;POCCVAP{yearsuffix}&#34;] = data[f&#34;CVAP{yearsuffix}&#34;] - data[f&#34;NHWCVAP{yearsuffix}&#34;]
 
     return data
 
@@ -251,13 +253,13 @@ def _variables(prefix, start, stop, suffix=&#34;E&#34;) -&gt; list:
         for t in range(start, stop+1)
     ]
 
-def _raw(geometry) -&gt; pd.DataFrame:
+def _raw(geometry, yearsuffix) -&gt; pd.DataFrame:
     &#34;&#34;&#34;
     Reads raw CVAP data from the local repository.
 
     Args:
         geometry (str): Level of geometry for which we&#39;re getting 2019 CVAP data.
-
+        yearsuffix(str): Last 2 digits of year for which data is retrieved.
     Returns:
         A DataFrame, where each block of 13 rows corresponds to an individual
         geometric unit (2010 Census Block Group, 2010 Census Tract) and each row
@@ -267,7 +269,7 @@ def _raw(geometry) -&gt; pd.DataFrame:
     # Get the filepath local to the repository, load in the raw data, and return
     # it to the caller.
     local = Path(__file__).parent.absolute()
-    return pd.read_csv(local/f&#34;local/{geometry}.zip&#34;, encoding=&#34;ISO-8859-1&#34;)</code></pre>
+    return pd.read_csv(local/f&#34;local/{geometry}10-{yearsuffix}.zip&#34;, encoding=&#34;ISO-8859-1&#34;)</code></pre>
 </details>
 </section>
 <section>
@@ -426,10 +428,10 @@ POC populations.</dd>
 </details>
 </dd>
 <dt id="evaltools.data.acs.cvap"><code class="name flex">
-<span>def <span class="ident">cvap</span></span>(<span>state, geometry='tract') ‑> pandas.core.frame.DataFrame</span>
+<span>def <span class="ident">cvap</span></span>(<span>state, geometry='tract', year=2019) ‑> pandas.core.frame.DataFrame</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Retrieves and CSV-formats 2019 5-year CVAP data for the provided state at
+<div class="desc"><p>Retrieves and CSV-formats 5-year CVAP data for the provided state at
 the specified geometry level. Geometries from the <strong>2010 Census</strong>. Variables
 and descriptions are <a href="https://tinyurl.com/3mnrm56s&gt;">listed here</a>.</p>
 <h2 id="args">Args</h2>
@@ -441,17 +443,19 @@ CVAP Special Tab.</dd>
 <dd>Level of geometry for which we're getting data.
 Accepted values are <code>"block group"</code> for 2010 Census Block Groups, and
 <code>"tract"</code> for 2010 Census Tracts. Defaults to <code>"tract"</code>.</dd>
+<dt><strong><code>year</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>Year for which data is retrieved. Defaults to 2019.</dd>
 </dl>
 <p>Returns
 A <code>DataFrame</code> with a <code>GEOID</code> column and corresponding CVAP columns from
-the 2019 ACS CVAP Special Tab.</p></div>
+the ACS CVAP Special Tab for the specified year.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def cvap(state, geometry=&#34;tract&#34;) -&gt; pd.DataFrame:
+<pre><code class="python">def cvap(state, geometry=&#34;tract&#34;, year=2019) -&gt; pd.DataFrame:
     &#34;&#34;&#34;
-    Retrieves and CSV-formats 2019 5-year CVAP data for the provided state at
+    Retrieves and CSV-formats 5-year CVAP data for the provided state at
     the specified geometry level. Geometries from the **2010 Census**. Variables
     and descriptions are [listed here](https://tinyurl.com/3mnrm56s&gt;).
 
@@ -461,10 +465,11 @@ the 2019 ACS CVAP Special Tab.</p></div>
         geometry (str, optional): Level of geometry for which we&#39;re getting data.
             Accepted values are `&#34;block group&#34;` for 2010 Census Block Groups, and
             `&#34;tract&#34;` for 2010 Census Tracts. Defaults to `&#34;tract&#34;`.
+        year (int, optional): Year for which data is retrieved. Defaults to 2019.
 
     Returns
         A `DataFrame` with a `GEOID` column and corresponding CVAP columns from
-        the 2019 ACS CVAP Special Tab.
+        the ACS CVAP Special Tab for the specified year.
     &#34;&#34;&#34;
     # Maps line numbers to descriptors.
     descriptions = {
@@ -489,8 +494,9 @@ the 2019 ACS CVAP Special Tab.</p></div>
         print(f&#34;Requested geometry \&#34;{geometry}\&#34; is not allowed; loading tracts.&#34;)
         geometry = &#34;tract&#34;
 
+    yearsuffix = str(year)[-2:]
     # Load the raw data.
-    raw = _raw(geometry)
+    raw = _raw(geometry, yearsuffix)
 
     # Create a STATE column for filtering and remove all rows which don&#39;t match
     # the state FIPS code.
@@ -517,15 +523,15 @@ the 2019 ACS CVAP Special Tab.</p></div>
         block = instate_records[i:i+13]
         for line in block:
             record[geometry.replace(&#34; &#34;, &#34;&#34;).upper() + &#34;10&#34;] = line[&#34;GEOID&#34;]
-            record[descriptions[line[&#34;lnnumber&#34;]] + &#34;19&#34;] = line[&#34;cvap_est&#34;]
-            record[descriptions[line[&#34;lnnumber&#34;]] + &#34;19e&#34;] = line[&#34;cvap_moe&#34;]
+            record[descriptions[line[&#34;lnnumber&#34;]] + yearsuffix] = line[&#34;cvap_est&#34;]
+            record[descriptions[line[&#34;lnnumber&#34;]] + f&#34;{yearsuffix}e&#34;] = line[&#34;cvap_moe&#34;]
 
         collapsed.append(record)
 
     # Create a dataframe and a POCCVAP column; all people minus non-Hispanic
     # White.
     data = pd.DataFrame().from_records(collapsed)
-    data[&#34;POCCVAP19&#34;] = data[&#34;CVAP19&#34;] - data[&#34;NHWCVAP19&#34;]
+    data[f&#34;POCCVAP{yearsuffix}&#34;] = data[f&#34;CVAP{yearsuffix}&#34;] - data[f&#34;NHWCVAP{yearsuffix}&#34;]
 
     return data</code></pre>
 </details>

--- a/docs/data/index.html
+++ b/docs/data/index.html
@@ -396,10 +396,10 @@ designation and a <code>GEOID20</code> column for joining to geometries.</p></di
 </details>
 </dd>
 <dt id="evaltools.data.cvap"><code class="name flex">
-<span>def <span class="ident">cvap</span></span>(<span>state, geometry='tract') ‑> pandas.core.frame.DataFrame</span>
+<span>def <span class="ident">cvap</span></span>(<span>state, geometry='tract', year=2019) ‑> pandas.core.frame.DataFrame</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Retrieves and CSV-formats 2019 5-year CVAP data for the provided state at
+<div class="desc"><p>Retrieves and CSV-formats 5-year CVAP data for the provided state at
 the specified geometry level. Geometries from the <strong>2010 Census</strong>. Variables
 and descriptions are <a href="https://tinyurl.com/3mnrm56s&gt;">listed here</a>.</p>
 <h2 id="args">Args</h2>
@@ -411,17 +411,19 @@ CVAP Special Tab.</dd>
 <dd>Level of geometry for which we're getting data.
 Accepted values are <code>"block group"</code> for 2010 Census Block Groups, and
 <code>"tract"</code> for 2010 Census Tracts. Defaults to <code>"tract"</code>.</dd>
+<dt><strong><code>year</code></strong> :&ensp;<code>int</code>, optional</dt>
+<dd>Year for which data is retrieved. Defaults to 2019.</dd>
 </dl>
 <p>Returns
 A <code>DataFrame</code> with a <code>GEOID</code> column and corresponding CVAP columns from
-the 2019 ACS CVAP Special Tab.</p></div>
+the ACS CVAP Special Tab for the specified year.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def cvap(state, geometry=&#34;tract&#34;) -&gt; pd.DataFrame:
+<pre><code class="python">def cvap(state, geometry=&#34;tract&#34;, year=2019) -&gt; pd.DataFrame:
     &#34;&#34;&#34;
-    Retrieves and CSV-formats 2019 5-year CVAP data for the provided state at
+    Retrieves and CSV-formats 5-year CVAP data for the provided state at
     the specified geometry level. Geometries from the **2010 Census**. Variables
     and descriptions are [listed here](https://tinyurl.com/3mnrm56s&gt;).
 
@@ -431,10 +433,11 @@ the 2019 ACS CVAP Special Tab.</p></div>
         geometry (str, optional): Level of geometry for which we&#39;re getting data.
             Accepted values are `&#34;block group&#34;` for 2010 Census Block Groups, and
             `&#34;tract&#34;` for 2010 Census Tracts. Defaults to `&#34;tract&#34;`.
+        year (int, optional): Year for which data is retrieved. Defaults to 2019.
 
     Returns
         A `DataFrame` with a `GEOID` column and corresponding CVAP columns from
-        the 2019 ACS CVAP Special Tab.
+        the ACS CVAP Special Tab for the specified year.
     &#34;&#34;&#34;
     # Maps line numbers to descriptors.
     descriptions = {
@@ -459,8 +462,9 @@ the 2019 ACS CVAP Special Tab.</p></div>
         print(f&#34;Requested geometry \&#34;{geometry}\&#34; is not allowed; loading tracts.&#34;)
         geometry = &#34;tract&#34;
 
+    yearsuffix = str(year)[-2:]
     # Load the raw data.
-    raw = _raw(geometry)
+    raw = _raw(geometry, yearsuffix)
 
     # Create a STATE column for filtering and remove all rows which don&#39;t match
     # the state FIPS code.
@@ -487,15 +491,15 @@ the 2019 ACS CVAP Special Tab.</p></div>
         block = instate_records[i:i+13]
         for line in block:
             record[geometry.replace(&#34; &#34;, &#34;&#34;).upper() + &#34;10&#34;] = line[&#34;GEOID&#34;]
-            record[descriptions[line[&#34;lnnumber&#34;]] + &#34;19&#34;] = line[&#34;cvap_est&#34;]
-            record[descriptions[line[&#34;lnnumber&#34;]] + &#34;19e&#34;] = line[&#34;cvap_moe&#34;]
+            record[descriptions[line[&#34;lnnumber&#34;]] + yearsuffix] = line[&#34;cvap_est&#34;]
+            record[descriptions[line[&#34;lnnumber&#34;]] + f&#34;{yearsuffix}e&#34;] = line[&#34;cvap_moe&#34;]
 
         collapsed.append(record)
 
     # Create a dataframe and a POCCVAP column; all people minus non-Hispanic
     # White.
     data = pd.DataFrame().from_records(collapsed)
-    data[&#34;POCCVAP19&#34;] = data[&#34;CVAP19&#34;] - data[&#34;NHWCVAP19&#34;]
+    data[f&#34;POCCVAP{yearsuffix}&#34;] = data[f&#34;CVAP{yearsuffix}&#34;] - data[f&#34;NHWCVAP{yearsuffix}&#34;]
 
     return data</code></pre>
 </details>

--- a/docs/scoring/index.html
+++ b/docs/scoring/index.html
@@ -42,7 +42,7 @@ from .reock import reock
 __all__ = [
     &#34;splits&#34;,
     &#34;pieces&#34;,
-    &#34;competitive_districts&#34;,
+    &#34;competitive_contests&#34;,
     &#34;swing_districts&#34;,
     &#34;party_districts&#34;,
     &#34;opp_party_districts&#34;,
@@ -51,6 +51,7 @@ __all__ = [
     &#34;signed_proportionality&#34;,
     &#34;absolute_proportionality&#34;,
     &#34;efficiency_gap&#34;,
+    &#34;simplified_efficiency_gap&#34;,
     &#34;mean_median&#34;,
     &#34;partisan_bias&#34;,
     &#34;partisan_gini&#34;,
@@ -141,11 +142,11 @@ elections.</p></div>
     return Score(&#34;absolute_proportionality&#34;, partial(_absolute_proportionality, election_cols=election_cols, party=party))</code></pre>
 </details>
 </dd>
-<dt id="evaltools.scoring.competitive_districts"><code class="name flex">
-<span>def <span class="ident">competitive_districts</span></span>(<span>election_cols: Iterable[str], party: str, points_within: float = 0.03) ‑> <a title="evaltools.scoring.score_types.Score" href="score_types.html#evaltools.scoring.score_types.Score">Score</a></span>
+<dt id="evaltools.scoring.competitive_contests"><code class="name flex">
+<span>def <span class="ident">competitive_contests</span></span>(<span>election_cols: Iterable[str], party: str, points_within: float = 0.03) ‑> <a title="evaltools.scoring.score_types.Score" href="score_types.html#evaltools.scoring.score_types.Score">Score</a></span>
 </code></dt>
 <dd>
-<div class="desc"><p>Score representing the number of competitive districts in a plan.</p>
+<div class="desc"><p>Score representing the number of competitive contests in a plan.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>election_cols</code></strong> :&ensp;<code>Iterable[str]</code></dt>
@@ -158,15 +159,15 @@ results for.</dd>
 Default is 0.03, corresponding to a competitive range of 47%-53%.</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<p>A score object with name <code>"competitive_districts"</code> and associated function that takes a
+<p>A score object with name <code>"competitive_contests_0.03"</code> and associated function that takes a
 partition and returns a PlanWideScoreValue for the number of competitive districts.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def competitive_districts(election_cols: Iterable[str], party: str, points_within: float = 0.03) -&gt; Score:
+<pre><code class="python">def competitive_contests(election_cols: Iterable[str], party: str, points_within: float = 0.03) -&gt; Score:
     &#34;&#34;&#34;
-    Score representing the number of competitive districts in a plan.
+    Score representing the number of competitive contests in a plan.
 
     Args:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
@@ -176,10 +177,12 @@ partition and returns a PlanWideScoreValue for the number of competitive distric
             Default is 0.03, corresponding to a competitive range of 47%-53%.
     
     Returns:
-        A score object with name `&#34;competitive_districts&#34;` and associated function that takes a
+        A score object with name `&#34;competitive_contests_0.03&#34;` and associated function that takes a
         partition and returns a PlanWideScoreValue for the number of competitive districts.
     &#34;&#34;&#34;
-    return Score(&#34;competitive_districts&#34;, partial(_competitive_districts, election_cols=election_cols,
+    if alias is None:
+        alias = f&#34;competitive_contests_{points_within}&#34;
+    return Score(alias, partial(_competitive_contests, election_cols=election_cols,
                                                   party=party, points_within=points_within))</code></pre>
 </details>
 </dd>
@@ -1160,6 +1163,44 @@ elections.</p></div>
     return Score(&#34;signed_proportionality&#34;, partial(_signed_proportionality, election_cols=election_cols, party=party))</code></pre>
 </details>
 </dd>
+<dt id="evaltools.scoring.simplified_efficiency_gap"><code class="name flex">
+<span>def <span class="ident">simplified_efficiency_gap</span></span>(<span>election_cols: Iterable[str], party: str) ‑> <a title="evaltools.scoring.score_types.Score" href="score_types.html#evaltools.scoring.score_types.Score">Score</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Score representing the simplified efficiency gap metric of a plan with respect to a set of elections.
+The original formulation of efficiency gap quantifies the difference in "wasted" votes for the two
+parties across the state, as a share of votes cast. This is sensitive to turnout effects. The
+simplified score is equal to standard efficiency gap when the districts have equal turnout.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>election_cols</code></strong> :&ensp;<code>Iterable[str]</code></dt>
+<dd>The names of the election updaters over which to compute
+results for.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A score object with name <code>"efficiency_gap"</code>
+and associated function that takes a partition
+and returns a PlanWideScoreValue for efficiency gap metric.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def simplified_efficiency_gap(election_cols: Iterable[str], party: str) -&gt; Score:
+    &#34;&#34;&#34;
+    Score representing the simplified efficiency gap metric of a plan with respect to a set of elections.
+    The original formulation of efficiency gap quantifies the difference in &#34;wasted&#34; votes for the two
+    parties across the state, as a share of votes cast. This is sensitive to turnout effects. The 
+    simplified score is equal to standard efficiency gap when the districts have equal turnout.
+    Args:
+        election_cols (Iterable[str]): The names of the election updaters over which to compute
+            results for.
+    Returns:
+        A score object with name `&#34;efficiency_gap&#34;`  and associated function that takes a partition
+        and returns a PlanWideScoreValue for efficiency gap metric.
+    &#34;&#34;&#34;
+    return Score(&#34;simplified_efficiency_gap&#34;, partial(_simplified_efficiency_gap, election_cols=election_cols, party=party))</code></pre>
+</details>
+</dd>
 <dt id="evaltools.scoring.splits"><code class="name flex">
 <span>def <span class="ident">splits</span></span>(<span>unit: str, names: bool = False, popcol: str = None, how: str = 'pandas', alias: str = None) ‑> <a title="evaltools.scoring.score_types.Score" href="score_types.html#evaltools.scoring.score_types.Score">Score</a></span>
 </code></dt>
@@ -1269,7 +1310,7 @@ applied to the plan.</p>
     &#34;&#34;&#34;
     summary = {}
     for score in scores:
-        summary[score.name] = score.function(part)
+        summary[score.name] = score.apply(part)
     return summary</code></pre>
 </details>
 </dd>
@@ -1533,7 +1574,7 @@ float: right;
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
 <li><code><a title="evaltools.scoring.absolute_proportionality" href="#evaltools.scoring.absolute_proportionality">absolute_proportionality</a></code></li>
-<li><code><a title="evaltools.scoring.competitive_districts" href="#evaltools.scoring.competitive_districts">competitive_districts</a></code></li>
+<li><code><a title="evaltools.scoring.competitive_contests" href="#evaltools.scoring.competitive_contests">competitive_contests</a></code></li>
 <li><code><a title="evaltools.scoring.contiguous" href="#evaltools.scoring.contiguous">contiguous</a></code></li>
 <li><code><a title="evaltools.scoring.demographic_shares" href="#evaltools.scoring.demographic_shares">demographic_shares</a></code></li>
 <li><code><a title="evaltools.scoring.demographic_tallies" href="#evaltools.scoring.demographic_tallies">demographic_tallies</a></code></li>
@@ -1552,6 +1593,7 @@ float: right;
 <li><code><a title="evaltools.scoring.reock" href="#evaltools.scoring.reock">reock</a></code></li>
 <li><code><a title="evaltools.scoring.seats" href="#evaltools.scoring.seats">seats</a></code></li>
 <li><code><a title="evaltools.scoring.signed_proportionality" href="#evaltools.scoring.signed_proportionality">signed_proportionality</a></code></li>
+<li><code><a title="evaltools.scoring.simplified_efficiency_gap" href="#evaltools.scoring.simplified_efficiency_gap">simplified_efficiency_gap</a></code></li>
 <li><code><a title="evaltools.scoring.splits" href="#evaltools.scoring.splits">splits</a></code></li>
 <li><code><a title="evaltools.scoring.summarize" href="#evaltools.scoring.summarize">summarize</a></code></li>
 <li><code><a title="evaltools.scoring.summarize_many" href="#evaltools.scoring.summarize_many">summarize_many</a></code></li>

--- a/docs/scoring/partisan.html
+++ b/docs/scoring/partisan.html
@@ -44,7 +44,7 @@ def _election_stability(part: Partition, election_cols: Tuple[str], party: str):
     return (_election_results(part, election_cols, party) &gt; 0.5).sum(axis=0)
 
 
-def _competitive_districts(part: Partition, election_cols: Iterable[str], party: str,
+def _competitive_contests(part: Partition, election_cols: Iterable[str], party: str,
                           points_within: float = 0.03) -&gt; PlanWideScoreValue:
     results = _election_results(part, tuple(election_cols), party)
     return int(np.logical_and(results &gt; 0.5 - points_within, results &lt; 0.5 + points_within).sum())
@@ -77,6 +77,14 @@ def _absolute_proportionality(part: Partition, election_cols: Iterable[str], par
 
 def _efficiency_gap(part: Partition, election_cols: Iterable[str]) -&gt; ElectionWideScoreValue:
     return {part[e].election.name: part[e].efficiency_gap() for e in election_cols}
+
+def _simplified_efficiency_gap(part: Partition, election_cols: Iterable[str], party: str) -&gt; ElectionWideScoreValue:
+    result = {}
+    for e in election_cols:
+        V = part[e].percent(party)
+        S = part[e].seats(party) / len(part)
+        result[part[e].election.name] = S + 0.5 - 2*V
+    return result
 
 def _mean_median(part: Partition, election_cols: Iterable[str]) -&gt; ElectionWideScoreValue:
     return {part[e].election.name: part[e].mean_median() for e in election_cols}

--- a/docs/scoring/scores.html
+++ b/docs/scoring/scores.html
@@ -34,13 +34,14 @@ from .demographics import (
     _gingles_districts,
 )
 from .partisan import (
-    _competitive_districts,
+    _competitive_contests,
     _swing_districts,
     _party_districts,
     _opp_party_districts,
     _party_wins_by_district,
     _seats,
     _efficiency_gap,
+    _simplified_efficiency_gap,
     _mean_median,
     _partisan_bias,
     _partisan_gini,
@@ -76,7 +77,7 @@ def summarize(part: Partition, scores: Iterable[Score]) -&gt; Dict[str, ScoreVal
     &#34;&#34;&#34;
     summary = {}
     for score in scores:
-        summary[score.name] = score.function(part)
+        summary[score.name] = score.apply(part)
     return summary
 
 def summarize_many(parts: Iterable[Partition], scores: Iterable[Score], plan_names: List[str] = [],
@@ -192,9 +193,9 @@ def pieces(
         partial(_pieces, unit=unit, how=how, popcol=popcol, names=names)
     )
 
-def competitive_districts(election_cols: Iterable[str], party: str, points_within: float = 0.03) -&gt; Score:
+def competitive_contests(election_cols: Iterable[str], party: str, points_within: float = 0.03) -&gt; Score:
     &#34;&#34;&#34;
-    Score representing the number of competitive districts in a plan.
+    Score representing the number of competitive contests in a plan.
 
     Args:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
@@ -204,10 +205,12 @@ def competitive_districts(election_cols: Iterable[str], party: str, points_withi
             Default is 0.03, corresponding to a competitive range of 47%-53%.
     
     Returns:
-        A score object with name `&#34;competitive_districts&#34;` and associated function that takes a
+        A score object with name `&#34;competitive_contests_0.03&#34;` and associated function that takes a
         partition and returns a PlanWideScoreValue for the number of competitive districts.
     &#34;&#34;&#34;
-    return Score(&#34;competitive_districts&#34;, partial(_competitive_districts, election_cols=election_cols,
+    if alias is None:
+        alias = f&#34;competitive_contests_{points_within}&#34;
+    return Score(alias, partial(_competitive_contests, election_cols=election_cols,
                                                   party=party, points_within=points_within))
 
 def swing_districts(election_cols: Iterable[str], party: str) -&gt; Score:
@@ -339,6 +342,21 @@ def efficiency_gap(election_cols: Iterable[str]) -&gt; Score:
         and returns a PlanWideScoreValue for efficiency gap metric.
     &#34;&#34;&#34;
     return Score(&#34;efficiency_gap&#34;, partial(_efficiency_gap, election_cols=election_cols))
+
+def simplified_efficiency_gap(election_cols: Iterable[str], party: str) -&gt; Score:
+    &#34;&#34;&#34;
+    Score representing the simplified efficiency gap metric of a plan with respect to a set of elections.
+    The original formulation of efficiency gap quantifies the difference in &#34;wasted&#34; votes for the two
+    parties across the state, as a share of votes cast. This is sensitive to turnout effects. The 
+    simplified score is equal to standard efficiency gap when the districts have equal turnout.
+    Args:
+        election_cols (Iterable[str]): The names of the election updaters over which to compute
+            results for.
+    Returns:
+        A score object with name `&#34;efficiency_gap&#34;`  and associated function that takes a partition
+        and returns a PlanWideScoreValue for efficiency gap metric.
+    &#34;&#34;&#34;
+    return Score(&#34;simplified_efficiency_gap&#34;, partial(_simplified_efficiency_gap, election_cols=election_cols, party=party))
 
 def mean_median(election_cols: Iterable[str]) -&gt; Score:
     &#34;&#34;&#34;
@@ -522,11 +540,11 @@ elections.</p></div>
     return Score(&#34;absolute_proportionality&#34;, partial(_absolute_proportionality, election_cols=election_cols, party=party))</code></pre>
 </details>
 </dd>
-<dt id="evaltools.scoring.scores.competitive_districts"><code class="name flex">
-<span>def <span class="ident">competitive_districts</span></span>(<span>election_cols: Iterable[str], party: str, points_within: float = 0.03) ‑> <a title="evaltools.scoring.score_types.Score" href="score_types.html#evaltools.scoring.score_types.Score">Score</a></span>
+<dt id="evaltools.scoring.scores.competitive_contests"><code class="name flex">
+<span>def <span class="ident">competitive_contests</span></span>(<span>election_cols: Iterable[str], party: str, points_within: float = 0.03) ‑> <a title="evaltools.scoring.score_types.Score" href="score_types.html#evaltools.scoring.score_types.Score">Score</a></span>
 </code></dt>
 <dd>
-<div class="desc"><p>Score representing the number of competitive districts in a plan.</p>
+<div class="desc"><p>Score representing the number of competitive contests in a plan.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>election_cols</code></strong> :&ensp;<code>Iterable[str]</code></dt>
@@ -539,15 +557,15 @@ results for.</dd>
 Default is 0.03, corresponding to a competitive range of 47%-53%.</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<p>A score object with name <code>"competitive_districts"</code> and associated function that takes a
+<p>A score object with name <code>"competitive_contests_0.03"</code> and associated function that takes a
 partition and returns a PlanWideScoreValue for the number of competitive districts.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def competitive_districts(election_cols: Iterable[str], party: str, points_within: float = 0.03) -&gt; Score:
+<pre><code class="python">def competitive_contests(election_cols: Iterable[str], party: str, points_within: float = 0.03) -&gt; Score:
     &#34;&#34;&#34;
-    Score representing the number of competitive districts in a plan.
+    Score representing the number of competitive contests in a plan.
 
     Args:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
@@ -557,10 +575,12 @@ partition and returns a PlanWideScoreValue for the number of competitive distric
             Default is 0.03, corresponding to a competitive range of 47%-53%.
     
     Returns:
-        A score object with name `&#34;competitive_districts&#34;` and associated function that takes a
+        A score object with name `&#34;competitive_contests_0.03&#34;` and associated function that takes a
         partition and returns a PlanWideScoreValue for the number of competitive districts.
     &#34;&#34;&#34;
-    return Score(&#34;competitive_districts&#34;, partial(_competitive_districts, election_cols=election_cols,
+    if alias is None:
+        alias = f&#34;competitive_contests_{points_within}&#34;
+    return Score(alias, partial(_competitive_contests, election_cols=election_cols,
                                                   party=party, points_within=points_within))</code></pre>
 </details>
 </dd>
@@ -1169,6 +1189,44 @@ elections.</p></div>
     return Score(&#34;signed_proportionality&#34;, partial(_signed_proportionality, election_cols=election_cols, party=party))</code></pre>
 </details>
 </dd>
+<dt id="evaltools.scoring.scores.simplified_efficiency_gap"><code class="name flex">
+<span>def <span class="ident">simplified_efficiency_gap</span></span>(<span>election_cols: Iterable[str], party: str) ‑> <a title="evaltools.scoring.score_types.Score" href="score_types.html#evaltools.scoring.score_types.Score">Score</a></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Score representing the simplified efficiency gap metric of a plan with respect to a set of elections.
+The original formulation of efficiency gap quantifies the difference in "wasted" votes for the two
+parties across the state, as a share of votes cast. This is sensitive to turnout effects. The
+simplified score is equal to standard efficiency gap when the districts have equal turnout.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>election_cols</code></strong> :&ensp;<code>Iterable[str]</code></dt>
+<dd>The names of the election updaters over which to compute
+results for.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>A score object with name <code>"efficiency_gap"</code>
+and associated function that takes a partition
+and returns a PlanWideScoreValue for efficiency gap metric.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def simplified_efficiency_gap(election_cols: Iterable[str], party: str) -&gt; Score:
+    &#34;&#34;&#34;
+    Score representing the simplified efficiency gap metric of a plan with respect to a set of elections.
+    The original formulation of efficiency gap quantifies the difference in &#34;wasted&#34; votes for the two
+    parties across the state, as a share of votes cast. This is sensitive to turnout effects. The 
+    simplified score is equal to standard efficiency gap when the districts have equal turnout.
+    Args:
+        election_cols (Iterable[str]): The names of the election updaters over which to compute
+            results for.
+    Returns:
+        A score object with name `&#34;efficiency_gap&#34;`  and associated function that takes a partition
+        and returns a PlanWideScoreValue for efficiency gap metric.
+    &#34;&#34;&#34;
+    return Score(&#34;simplified_efficiency_gap&#34;, partial(_simplified_efficiency_gap, election_cols=election_cols, party=party))</code></pre>
+</details>
+</dd>
 <dt id="evaltools.scoring.scores.splits"><code class="name flex">
 <span>def <span class="ident">splits</span></span>(<span>unit: str, names: bool = False, popcol: str = None, how: str = 'pandas', alias: str = None) ‑> <a title="evaltools.scoring.score_types.Score" href="score_types.html#evaltools.scoring.score_types.Score">Score</a></span>
 </code></dt>
@@ -1278,7 +1336,7 @@ applied to the plan.</p>
     &#34;&#34;&#34;
     summary = {}
     for score in scores:
-        summary[score.name] = score.function(part)
+        summary[score.name] = score.apply(part)
     return summary</code></pre>
 </details>
 </dd>
@@ -1447,7 +1505,7 @@ float: right;
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
 <li><code><a title="evaltools.scoring.scores.absolute_proportionality" href="#evaltools.scoring.scores.absolute_proportionality">absolute_proportionality</a></code></li>
-<li><code><a title="evaltools.scoring.scores.competitive_districts" href="#evaltools.scoring.scores.competitive_districts">competitive_districts</a></code></li>
+<li><code><a title="evaltools.scoring.scores.competitive_contests" href="#evaltools.scoring.scores.competitive_contests">competitive_contests</a></code></li>
 <li><code><a title="evaltools.scoring.scores.demographic_shares" href="#evaltools.scoring.scores.demographic_shares">demographic_shares</a></code></li>
 <li><code><a title="evaltools.scoring.scores.demographic_tallies" href="#evaltools.scoring.scores.demographic_tallies">demographic_tallies</a></code></li>
 <li><code><a title="evaltools.scoring.scores.efficiency_gap" href="#evaltools.scoring.scores.efficiency_gap">efficiency_gap</a></code></li>
@@ -1462,6 +1520,7 @@ float: right;
 <li><code><a title="evaltools.scoring.scores.pieces" href="#evaltools.scoring.scores.pieces">pieces</a></code></li>
 <li><code><a title="evaltools.scoring.scores.seats" href="#evaltools.scoring.scores.seats">seats</a></code></li>
 <li><code><a title="evaltools.scoring.scores.signed_proportionality" href="#evaltools.scoring.scores.signed_proportionality">signed_proportionality</a></code></li>
+<li><code><a title="evaltools.scoring.scores.simplified_efficiency_gap" href="#evaltools.scoring.scores.simplified_efficiency_gap">simplified_efficiency_gap</a></code></li>
 <li><code><a title="evaltools.scoring.scores.splits" href="#evaltools.scoring.scores.splits">splits</a></code></li>
 <li><code><a title="evaltools.scoring.scores.summarize" href="#evaltools.scoring.scores.summarize">summarize</a></code></li>
 <li><code><a title="evaltools.scoring.scores.summarize_many" href="#evaltools.scoring.scores.summarize_many">summarize_many</a></code></li>

--- a/evaltools/scoring/__init__.py
+++ b/evaltools/scoring/__init__.py
@@ -13,7 +13,7 @@ from .reock import reock
 __all__ = [
     "splits",
     "pieces",
-    "competitive_districts",
+    "competitive_contests",
     "swing_districts",
     "party_districts",
     "opp_party_districts",
@@ -22,6 +22,7 @@ __all__ = [
     "signed_proportionality",
     "absolute_proportionality",
     "efficiency_gap",
+    "simplified_efficiency_gap",
     "mean_median",
     "partisan_bias",
     "partisan_gini",

--- a/evaltools/scoring/partisan.py
+++ b/evaltools/scoring/partisan.py
@@ -15,7 +15,7 @@ def _election_stability(part: Partition, election_cols: Tuple[str], party: str):
     return (_election_results(part, election_cols, party) > 0.5).sum(axis=0)
 
 
-def _competitive_districts(part: Partition, election_cols: Iterable[str], party: str,
+def _competitive_contests(part: Partition, election_cols: Iterable[str], party: str,
                           points_within: float = 0.03) -> PlanWideScoreValue:
     results = _election_results(part, tuple(election_cols), party)
     return int(np.logical_and(results > 0.5 - points_within, results < 0.5 + points_within).sum())
@@ -48,6 +48,14 @@ def _absolute_proportionality(part: Partition, election_cols: Iterable[str], par
 
 def _efficiency_gap(part: Partition, election_cols: Iterable[str]) -> ElectionWideScoreValue:
     return {part[e].election.name: part[e].efficiency_gap() for e in election_cols}
+
+def _simplified_efficiency_gap(part: Partition, election_cols: Iterable[str], party: str) -> ElectionWideScoreValue:
+    result = {}
+    for e in election_cols:
+        V = part[e].percent(party)
+        S = part[e].seats(party) / len(part)
+        result[part[e].election.name] = S + 0.5 - 2*V
+    return result
 
 def _mean_median(part: Partition, election_cols: Iterable[str]) -> ElectionWideScoreValue:
     return {part[e].election.name: part[e].mean_median() for e in election_cols}

--- a/evaltools/scoring/scores.py
+++ b/evaltools/scoring/scores.py
@@ -5,13 +5,14 @@ from .demographics import (
     _gingles_districts,
 )
 from .partisan import (
-    _competitive_districts,
+    _competitive_contests,
     _swing_districts,
     _party_districts,
     _opp_party_districts,
     _party_wins_by_district,
     _seats,
     _efficiency_gap,
+    _simplified_efficiency_gap,
     _mean_median,
     _partisan_bias,
     _partisan_gini,
@@ -163,9 +164,9 @@ def pieces(
         partial(_pieces, unit=unit, how=how, popcol=popcol, names=names)
     )
 
-def competitive_districts(election_cols: Iterable[str], party: str, points_within: float = 0.03) -> Score:
+def competitive_contests(election_cols: Iterable[str], party: str, points_within: float = 0.03) -> Score:
     """
-    Score representing the number of competitive districts in a plan.
+    Score representing the number of competitive contests in a plan.
 
     Args:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
@@ -175,10 +176,12 @@ def competitive_districts(election_cols: Iterable[str], party: str, points_withi
             Default is 0.03, corresponding to a competitive range of 47%-53%.
     
     Returns:
-        A score object with name `"competitive_districts"` and associated function that takes a
+        A score object with name `"competitive_contests_0.03"` and associated function that takes a
         partition and returns a PlanWideScoreValue for the number of competitive districts.
     """
-    return Score("competitive_districts", partial(_competitive_districts, election_cols=election_cols,
+    if alias is None:
+        alias = f"competitive_contests_{points_within}"
+    return Score(alias, partial(_competitive_contests, election_cols=election_cols,
                                                   party=party, points_within=points_within))
 
 def swing_districts(election_cols: Iterable[str], party: str) -> Score:
@@ -310,6 +313,21 @@ def efficiency_gap(election_cols: Iterable[str]) -> Score:
         and returns a PlanWideScoreValue for efficiency gap metric.
     """
     return Score("efficiency_gap", partial(_efficiency_gap, election_cols=election_cols))
+
+def simplified_efficiency_gap(election_cols: Iterable[str], party: str) -> Score:
+    """
+    Score representing the simplified efficiency gap metric of a plan with respect to a set of elections.
+    The original formulation of efficiency gap quantifies the difference in "wasted" votes for the two
+    parties across the state, as a share of votes cast. This is sensitive to turnout effects. The 
+    simplified score is equal to standard efficiency gap when the districts have equal turnout.
+    Args:
+        election_cols (Iterable[str]): The names of the election updaters over which to compute
+            results for.
+    Returns:
+        A score object with name `"efficiency_gap"`  and associated function that takes a partition
+        and returns a PlanWideScoreValue for efficiency gap metric.
+    """
+    return Score("simplified_efficiency_gap", partial(_simplified_efficiency_gap, election_cols=election_cols, party=party))
 
 def mean_median(election_cols: Iterable[str]) -> Score:
     """


### PR DESCRIPTION
This is a quick PR to address the first commit in [this old PR](https://github.com/mggg/evaltools/pull/33). Quoting from there, we have:
> This adds our S + 0.5 - 2V formulation of the efficiency gap to our scoring toolkit. I also made some small changes to the competitive_districts() function, changing its name and allowing one to use an alias for the name field. This would be helpful if one wants to calculate the number of competitive contests according to several different sets of elections, so you could distinguish between them.

Once this is merged in, we could/should delete that old PR, since the ensuing commits about reock and polsby-popper will be addressed better in our [contour-based compactness scores PR](https://github.com/mggg/evaltools/pull/43).