### PR TITLE
Option to average partisan scores, and max deviation score

### DIFF
--- a/evaltools/scoring/__init__.py
+++ b/evaltools/scoring/__init__.py
@@ -37,5 +37,6 @@ __all__ = [
     "demographic_tallies",
     "demographic_shares",
     "gingles_districts",
+    "max_deviation",
     "eguia",
 ]

--- a/evaltools/scoring/demographics.py
+++ b/evaltools/scoring/demographics.py
@@ -20,3 +20,9 @@ def _pop_shares(part: Partition, subpop_col: str, totpop_col: str) -> DistrictWi
 def _gingles_districts(part: Partition, subpop_col: str, totpop_col: str, threshold: float = 0.5) -> PlanWideScoreValue:
     subpop_shares = _pop_shares(part, subpop_col, totpop_col)
     return sum([share >= threshold for share in subpop_shares.values()])
+
+def _max_deviation(part: Partition, totpop_col: str, pct: bool = False) -> Numeric:
+    totpop_counts = _tally_pop(part, totpop_col)
+    ideal_population = sum(totpop_counts.values()) / len(part)
+    max_deviation = max([abs(pop - ideal_population) for pop in totpop_counts.values()])
+    return max_deviation / ideal_population if pct else max_deviation

--- a/evaltools/scoring/partisan.py
+++ b/evaltools/scoring/partisan.py
@@ -37,35 +37,41 @@ def _party_wins_by_district(part: Partition, election_cols: Iterable[str], party
     districts = [d for d in sorted(part.parts.keys()) if d != -1]
     return {d: int(d_wins) for d, d_wins in zip(districts, stability)}
 
-def _seats(part: Partition, election_cols: Iterable[str], party: str) -> ElectionWideScoreValue:
-    return {part[e].election.name: sum([part[e].won(party, d) for d in part.parts.keys() if d != -1]) for e in election_cols}
+def _seats(part: Partition, election_cols: Iterable[str], party: str, mean: bool = False) -> ScoreValue:
+    result = {part[e].election.name: sum([part[e].won(party, d) for d in part.parts.keys() if d != -1]) for e in election_cols}
+    return np.mean(result.values()) if mean else result
 
-def _signed_proportionality(part: Partition, election_cols: Iterable[str], party: str) -> ElectionWideScoreValue:
-    return {part[e].election.name: part[e].seats(party) - (part[e].percent(party) * len(part)) for e in election_cols}
+def _signed_proportionality(part: Partition, election_cols: Iterable[str], party: str, mean: bool = False) -> ScoreValue:
+    result = {part[e].election.name: part[e].seats(party) - (part[e].percent(party) * len(part)) for e in election_cols}
+    return np.mean(result.values()) if mean else result
 
-def _absolute_proportionality(part: Partition, election_cols: Iterable[str], party: str) -> ElectionWideScoreValue:
-    return {part[e].election.name: abs(part[e].seats(party) - (part[e].percent(party) * len(part))) for e in election_cols}
+def _absolute_proportionality(part: Partition, election_cols: Iterable[str], party: str, mean: bool = False) -> ScoreValue:
+    result = {part[e].election.name: abs(part[e].seats(party) - (part[e].percent(party) * len(part))) for e in election_cols}
+    return np.mean(result.values()) if mean else result
 
-def _efficiency_gap(part: Partition, election_cols: Iterable[str]) -> ElectionWideScoreValue:
-    return {part[e].election.name: part[e].efficiency_gap() for e in election_cols}
+def _efficiency_gap(part: Partition, election_cols: Iterable[str], mean: bool = False) -> ScoreValue:
+    result = {part[e].election.name: part[e].efficiency_gap() for e in election_cols}
+    return np.mean(result.values()) if mean else result
 
-def _simplified_efficiency_gap(part: Partition, election_cols: Iterable[str], party: str) -> ElectionWideScoreValue:
+def _simplified_efficiency_gap(part: Partition, election_cols: Iterable[str], party: str, mean: bool = False) -> ScoreValue:
     result = {}
     for e in election_cols:
         V = part[e].percent(party)
         S = part[e].seats(party) / len(part)
         result[part[e].election.name] = S + 0.5 - 2*V
-    return result
+    return np.mean(result.values()) if mean else result
 
-def _mean_median(part: Partition, election_cols: Iterable[str]) -> ElectionWideScoreValue:
-    return {part[e].election.name: part[e].mean_median() for e in election_cols}
+def _mean_median(part: Partition, election_cols: Iterable[str], mean: bool = False) -> ScoreValue:
+    result = {part[e].election.name: part[e].mean_median() for e in election_cols}
+    return np.mean(result.values()) if mean else result
 
-def _partisan_bias(part: Partition, election_cols: Iterable[str]) -> ElectionWideScoreValue:
-    return {part[e].election.name: part[e].partisan_bias() for e in election_cols}
+def _partisan_bias(part: Partition, election_cols: Iterable[str], mean: bool = False) -> ScoreValue:
+    result = {part[e].election.name: part[e].partisan_bias() for e in election_cols}
+    return np.mean(result.values()) if mean else result
 
-def _partisan_gini(part: Partition, election_cols: Iterable[str]) -> ElectionWideScoreValue:
-    return {part[e].election.name: part[e].partisan_gini() for e in election_cols}
-
+def _partisan_gini(part: Partition, election_cols: Iterable[str], mean: bool = False) -> ScoreValue:
+    result = {part[e].election.name: part[e].partisan_gini() for e in election_cols}
+    return np.mean(result.values()) if mean else result
 
 def _eguia_election(part: Partition, e: str, party: str, county_part: Partition, totpop_col: str) -> Numeric:
         seat_share = part[e].seats(party) / len(part.parts)
@@ -76,5 +82,6 @@ def _eguia_election(part: Partition, e: str, party: str, county_part: Partition,
         return seat_share - ideal
 
 
-def _eguia(part: Partition, election_cols: Iterable[str], party: str, county_part: Partition, totpop_col: str) -> ElectionWideScoreValue:
-    return {part[e].election.name: _eguia_election(part, e, party, county_part, totpop_col) for e in election_cols}
+def _eguia(part: Partition, election_cols: Iterable[str], party: str, county_part: Partition, totpop_col: str, mean: bool = False) -> ScoreValue:
+    result = {part[e].election.name: _eguia_election(part, e, party, county_part, totpop_col) for e in election_cols}
+    return np.mean(result.values()) if mean else result

--- a/evaltools/scoring/partisan.py
+++ b/evaltools/scoring/partisan.py
@@ -39,19 +39,19 @@ def _party_wins_by_district(part: Partition, election_cols: Iterable[str], party
 
 def _seats(part: Partition, election_cols: Iterable[str], party: str, mean: bool = False) -> ScoreValue:
     result = {part[e].election.name: sum([part[e].won(party, d) for d in part.parts.keys() if d != -1]) for e in election_cols}
-    return np.mean(result.values()) if mean else result
+    return np.mean(list(result.values())) if mean else result
 
 def _signed_proportionality(part: Partition, election_cols: Iterable[str], party: str, mean: bool = False) -> ScoreValue:
     result = {part[e].election.name: part[e].seats(party) - (part[e].percent(party) * len(part)) for e in election_cols}
-    return np.mean(result.values()) if mean else result
+    return np.mean(list(result.values())) if mean else result
 
 def _absolute_proportionality(part: Partition, election_cols: Iterable[str], party: str, mean: bool = False) -> ScoreValue:
     result = {part[e].election.name: abs(part[e].seats(party) - (part[e].percent(party) * len(part))) for e in election_cols}
-    return np.mean(result.values()) if mean else result
+    return np.mean(list(result.values())) if mean else result
 
 def _efficiency_gap(part: Partition, election_cols: Iterable[str], mean: bool = False) -> ScoreValue:
     result = {part[e].election.name: part[e].efficiency_gap() for e in election_cols}
-    return np.mean(result.values()) if mean else result
+    return np.mean(list(result.values())) if mean else result
 
 def _simplified_efficiency_gap(part: Partition, election_cols: Iterable[str], party: str, mean: bool = False) -> ScoreValue:
     result = {}
@@ -59,19 +59,19 @@ def _simplified_efficiency_gap(part: Partition, election_cols: Iterable[str], pa
         V = part[e].percent(party)
         S = part[e].seats(party) / len(part)
         result[part[e].election.name] = S + 0.5 - 2*V
-    return np.mean(result.values()) if mean else result
+    return np.mean(list(result.values())) if mean else result
 
 def _mean_median(part: Partition, election_cols: Iterable[str], mean: bool = False) -> ScoreValue:
     result = {part[e].election.name: part[e].mean_median() for e in election_cols}
-    return np.mean(result.values()) if mean else result
+    return np.mean(list(result.values())) if mean else result
 
 def _partisan_bias(part: Partition, election_cols: Iterable[str], mean: bool = False) -> ScoreValue:
     result = {part[e].election.name: part[e].partisan_bias() for e in election_cols}
-    return np.mean(result.values()) if mean else result
+    return np.mean(list(result.values())) if mean else result
 
 def _partisan_gini(part: Partition, election_cols: Iterable[str], mean: bool = False) -> ScoreValue:
     result = {part[e].election.name: part[e].partisan_gini() for e in election_cols}
-    return np.mean(result.values()) if mean else result
+    return np.mean(list(result.values())) if mean else result
 
 def _eguia_election(part: Partition, e: str, party: str, county_part: Partition, totpop_col: str) -> Numeric:
         seat_share = part[e].seats(party) / len(part.parts)
@@ -84,4 +84,4 @@ def _eguia_election(part: Partition, e: str, party: str, county_part: Partition,
 
 def _eguia(part: Partition, election_cols: Iterable[str], party: str, county_part: Partition, totpop_col: str, mean: bool = False) -> ScoreValue:
     result = {part[e].election.name: _eguia_election(part, e, party, county_part, totpop_col) for e in election_cols}
-    return np.mean(result.values()) if mean else result
+    return np.mean(list(result.values())) if mean else result

--- a/evaltools/scoring/scores.py
+++ b/evaltools/scoring/scores.py
@@ -251,7 +251,7 @@ def party_wins_by_district(election_cols: Iterable[str], party: str) -> Score:
     """
     return Score("party_wins_by_district", partial(_party_wins_by_district, election_cols=election_cols, party=party))
 
-def seats(election_cols: Iterable[str], party: str) -> Score:
+def seats(election_cols: Iterable[str], party: str, mean: bool = False) -> Score:
     """
     Score representing how many seats (districts) within a given plan the POV party won in each
     election 
@@ -260,6 +260,8 @@ def seats(election_cols: Iterable[str], party: str) -> Score:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
             results for.
         party (str): The "point of view" political party.
+        mean (bool): Whether to return the mean of the score over all elections, or a dictionary
+                     of the score for each election.
 
     Returns:
         A score object with name `"{party}_seats"` and associated function that takes a partition and
@@ -268,7 +270,7 @@ def seats(election_cols: Iterable[str], party: str) -> Score:
     """
     return Score(f"{party}_seats", partial(_seats, election_cols=election_cols, party=party))
 
-def signed_proportionality(election_cols: Iterable[str], party: str) -> Score:
+def signed_proportionality(election_cols: Iterable[str], party: str, mean: bool = False) -> Score:
     """
     Score representing how many the responsive proportionality across a set of elections.
 
@@ -276,6 +278,8 @@ def signed_proportionality(election_cols: Iterable[str], party: str) -> Score:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
             results for.
         party (str): The "point of view" political party.
+        mean (bool): Whether to return the mean of the score over all elections, or a dictionary
+                     of the score for each election.
 
     Returns:
         A score object with name `"signed_proportionality"` and associated function that takes a
@@ -284,7 +288,7 @@ def signed_proportionality(election_cols: Iterable[str], party: str) -> Score:
     """
     return Score("signed_proportionality", partial(_signed_proportionality, election_cols=election_cols, party=party))
 
-def absolute_proportionality(election_cols: Iterable[str], party: str) -> Score:
+def absolute_proportionality(election_cols: Iterable[str], party: str, mean: bool = False) -> Score:
     """
     Score representing how many the stable proportionality across a set of elections.
 
@@ -292,6 +296,8 @@ def absolute_proportionality(election_cols: Iterable[str], party: str) -> Score:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
             results for.
         party (str): The "point of view" political party.
+        mean (bool): Whether to return the mean of the score over all elections, or a dictionary
+                     of the score for each election.
 
     Returns:
         A score object with name `"absolute_proportionality"` and associated function that takes a
@@ -300,13 +306,15 @@ def absolute_proportionality(election_cols: Iterable[str], party: str) -> Score:
     """
     return Score("absolute_proportionality", partial(_absolute_proportionality, election_cols=election_cols, party=party))
 
-def efficiency_gap(election_cols: Iterable[str]) -> Score:
+def efficiency_gap(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
     Score representing the efficiency gap metric of a plan with respect to a set of elections.
 
     Args:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
             results for.
+        mean (bool): Whether to return the mean of the score over all elections, or a dictionary
+                     of the score for each election.
 
     Returns:
         A score object with name `"efficiency_gap"`  and associated function that takes a partition
@@ -314,7 +322,7 @@ def efficiency_gap(election_cols: Iterable[str]) -> Score:
     """
     return Score("efficiency_gap", partial(_efficiency_gap, election_cols=election_cols))
 
-def simplified_efficiency_gap(election_cols: Iterable[str], party: str) -> Score:
+def simplified_efficiency_gap(election_cols: Iterable[str], party: str, mean: bool = False) -> Score:
     """
     Score representing the simplified efficiency gap metric of a plan with respect to a set of elections.
     The original formulation of efficiency gap quantifies the difference in "wasted" votes for the two
@@ -323,19 +331,24 @@ def simplified_efficiency_gap(election_cols: Iterable[str], party: str) -> Score
     Args:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
             results for.
+        party (str): The "point of view" political party.
+        mean (bool): Whether to return the mean of the score over all elections, or a dictionary
+                     of the score for each election.
     Returns:
         A score object with name `"efficiency_gap"`  and associated function that takes a partition
         and returns a PlanWideScoreValue for efficiency gap metric.
     """
     return Score("simplified_efficiency_gap", partial(_simplified_efficiency_gap, election_cols=election_cols, party=party))
 
-def mean_median(election_cols: Iterable[str]) -> Score:
+def mean_median(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
     Score representing the mean median metric of a plan with respect to a set of elections.
 
     Args:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
             results for.
+        mean (bool): Whether to return the mean of the score over all elections, or a dictionary
+                     of the score for each election.
 
     Returns:
         A score object with name `"mean_median"` and associated function that takes a partition and
@@ -343,20 +356,22 @@ def mean_median(election_cols: Iterable[str]) -> Score:
     """
     return Score("mean_median", partial(_mean_median, election_cols=election_cols))
 
-def partisan_bias(election_cols: Iterable[str]) -> Score:
+def partisan_bias(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
     Score representing the partitisan bias metric of a plan with respect to a set of elections.
 
     Args:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
             results for.
+        mean (bool): Whether to return the mean of the score over all elections, or a dictionary
+                     of the score for each election.
     Returns:
         A score object with name `"partisan_bias"` and associated function that takes a partition and
         returns a PlanWideScoreValue for partisan bias metric.
     """
     return Score("partisan_bias", partial(_partisan_bias, election_cols=election_cols))
 
-def partisan_gini(election_cols: Iterable[str]) -> Score:
+def partisan_gini(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
     Score representing the partisan gini metric of a plan with respect to a set of elections.
 
@@ -364,6 +379,8 @@ def partisan_gini(election_cols: Iterable[str]) -> Score:
         election_cols (Iterable[str]): The names of the election updaters over which to compute
             results for.
         party (str): The "point of view" political party.
+        mean (bool): Whether to return the mean of the score over all elections, or a dictionary
+                     of the score for each election.
 
     Returns:
         A score object with name `"partisan_gini"` and associated function that takes a partition and
@@ -372,7 +389,7 @@ def partisan_gini(election_cols: Iterable[str]) -> Score:
     return Score("partisan_gini", partial(_partisan_gini, election_cols=election_cols))
 
 def eguia(election_cols: Iterable[str], party: str, graph: Graph, updaters: Mapping[str, Callable[[Partition], ScoreValue]],
-          county_col: str, totpop_col: str = "population") -> Score:
+          county_col: str, totpop_col: str = "population", mean: bool = False) -> Score:
     """
     Score representing the Equia metric of a plan with respect to a set of elections.
 
@@ -389,6 +406,8 @@ def eguia(election_cols: Iterable[str], party: str, graph: Graph, updaters: Mapp
             each unit.
         totpop_col (str, optional): The name of the updater that computes total population by
             district.
+        mean (bool): Whether to return the mean of the score over all elections, or a dictionary
+                     of the score for each election.
 
     Returns:
         A score object with name `"eguia"` and associated function that takes a partition and returns

--- a/evaltools/scoring/scores.py
+++ b/evaltools/scoring/scores.py
@@ -3,6 +3,7 @@ from .demographics import (
     _pop_shares,
     _tally_pop,
     _gingles_districts,
+    _max_deviation,
 )
 from .partisan import (
     _competitive_contests,
@@ -268,7 +269,7 @@ def seats(election_cols: Iterable[str], party: str, mean: bool = False) -> Score
         returns an ElectionWideScoreValue for the number of seats won by the POV party for each
         election.
     """
-    return Score(f"{party}_seats", partial(_seats, election_cols=election_cols, party=party))
+    return Score(f"{party}_seats", partial(_seats, election_cols=election_cols, party=party, mean=mean))
 
 def signed_proportionality(election_cols: Iterable[str], party: str, mean: bool = False) -> Score:
     """
@@ -286,7 +287,7 @@ def signed_proportionality(election_cols: Iterable[str], party: str, mean: bool 
         partition and returns an PlanWideScoreValue for the responsive proportionality across the
         elections.
     """
-    return Score("signed_proportionality", partial(_signed_proportionality, election_cols=election_cols, party=party))
+    return Score("signed_proportionality", partial(_signed_proportionality, election_cols=election_cols, party=party, mean=mean))
 
 def absolute_proportionality(election_cols: Iterable[str], party: str, mean: bool = False) -> Score:
     """
@@ -304,7 +305,7 @@ def absolute_proportionality(election_cols: Iterable[str], party: str, mean: boo
         partition and returns an PlanWideScoreValue for the stable proportionality across the
         elections.
     """
-    return Score("absolute_proportionality", partial(_absolute_proportionality, election_cols=election_cols, party=party))
+    return Score("absolute_proportionality", partial(_absolute_proportionality, election_cols=election_cols, party=party, mean=mean))
 
 def efficiency_gap(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
@@ -320,7 +321,7 @@ def efficiency_gap(election_cols: Iterable[str], mean: bool = False) -> Score:
         A score object with name `"efficiency_gap"`  and associated function that takes a partition
         and returns a PlanWideScoreValue for efficiency gap metric.
     """
-    return Score("efficiency_gap", partial(_efficiency_gap, election_cols=election_cols))
+    return Score("efficiency_gap", partial(_efficiency_gap, election_cols=election_cols, mean=mean))
 
 def simplified_efficiency_gap(election_cols: Iterable[str], party: str, mean: bool = False) -> Score:
     """
@@ -338,7 +339,7 @@ def simplified_efficiency_gap(election_cols: Iterable[str], party: str, mean: bo
         A score object with name `"efficiency_gap"`  and associated function that takes a partition
         and returns a PlanWideScoreValue for efficiency gap metric.
     """
-    return Score("simplified_efficiency_gap", partial(_simplified_efficiency_gap, election_cols=election_cols, party=party))
+    return Score("simplified_efficiency_gap", partial(_simplified_efficiency_gap, election_cols=election_cols, party=party, mean=mean))
 
 def mean_median(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
@@ -354,7 +355,7 @@ def mean_median(election_cols: Iterable[str], mean: bool = False) -> Score:
         A score object with name `"mean_median"` and associated function that takes a partition and
         returns a PlanWideScoreValue for the mean median metric.
     """
-    return Score("mean_median", partial(_mean_median, election_cols=election_cols))
+    return Score("mean_median", partial(_mean_median, election_cols=election_cols, mean=mean))
 
 def partisan_bias(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
@@ -369,7 +370,7 @@ def partisan_bias(election_cols: Iterable[str], mean: bool = False) -> Score:
         A score object with name `"partisan_bias"` and associated function that takes a partition and
         returns a PlanWideScoreValue for partisan bias metric.
     """
-    return Score("partisan_bias", partial(_partisan_bias, election_cols=election_cols))
+    return Score("partisan_bias", partial(_partisan_bias, election_cols=election_cols, mean=mean))
 
 def partisan_gini(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
@@ -386,7 +387,7 @@ def partisan_gini(election_cols: Iterable[str], mean: bool = False) -> Score:
         A score object with name `"partisan_gini"` and associated function that takes a partition and
         returns a PlanWideScoreValue for the partisan gini metric.
     """
-    return Score("partisan_gini", partial(_partisan_gini, election_cols=election_cols))
+    return Score("partisan_gini", partial(_partisan_gini, election_cols=election_cols, mean=mean))
 
 def eguia(election_cols: Iterable[str], party: str, graph: Graph, updaters: Mapping[str, Callable[[Partition], ScoreValue]],
           county_col: str, totpop_col: str = "population", mean: bool = False) -> Score:
@@ -415,7 +416,7 @@ def eguia(election_cols: Iterable[str], party: str, graph: Graph, updaters: Mapp
     """
     county_part = Partition(graph, county_col, updaters=updaters)
     return Score("eguia", partial(_eguia, election_cols=election_cols, party=party, 
-                                  county_part=county_part, totpop_col=totpop_col))
+                                  county_part=county_part, totpop_col=totpop_col, mean=mean))
 
 
 def demographic_tallies(population_cols: Iterable[str]) -> List[Score]:
@@ -483,3 +484,16 @@ def gingles_districts(population_cols: Mapping[str, Iterable[str]], threshold: f
             for col in subpop_cols
         ])
     return scores
+
+def max_deviation(totpop_col: str, pct: bool = False) -> Score:
+    """
+    Returns the maximum deviation from ideal population size among all the districts.
+    If `pct`, return the deviation as a percentage of ideal population size.
+
+    Args:
+        totpop_col (str, optional): The name of the updater that computes total population by
+            district.
+        pct (bool): Whether to return the maximum deviation as a count or as a percentage of 
+                    ideal district size.
+    """
+    return Score(f"{totpop_col}_max_deviation", partial(_max_deviation, totpop_col=totpop_col, pct=pct))

--- a/evaltools/scoring/scores.py
+++ b/evaltools/scoring/scores.py
@@ -269,7 +269,8 @@ def seats(election_cols: Iterable[str], party: str, mean: bool = False) -> Score
         returns an ElectionWideScoreValue for the number of seats won by the POV party for each
         election.
     """
-    return Score(f"{party}_seats", partial(_seats, election_cols=election_cols, party=party, mean=mean))
+    prefix = "mean_" if mean else ""
+    return Score(f"{prefix}{party}_seats", partial(_seats, election_cols=election_cols, party=party, mean=mean))
 
 def signed_proportionality(election_cols: Iterable[str], party: str, mean: bool = False) -> Score:
     """
@@ -287,7 +288,8 @@ def signed_proportionality(election_cols: Iterable[str], party: str, mean: bool 
         partition and returns an PlanWideScoreValue for the responsive proportionality across the
         elections.
     """
-    return Score("signed_proportionality", partial(_signed_proportionality, election_cols=election_cols, party=party, mean=mean))
+    prefix = "mean_" if mean else ""
+    return Score(f"{prefix}signed_proportionality", partial(_signed_proportionality, election_cols=election_cols, party=party, mean=mean))
 
 def absolute_proportionality(election_cols: Iterable[str], party: str, mean: bool = False) -> Score:
     """
@@ -305,7 +307,8 @@ def absolute_proportionality(election_cols: Iterable[str], party: str, mean: boo
         partition and returns an PlanWideScoreValue for the stable proportionality across the
         elections.
     """
-    return Score("absolute_proportionality", partial(_absolute_proportionality, election_cols=election_cols, party=party, mean=mean))
+    prefix = "mean_" if mean else ""
+    return Score(f"{prefix}absolute_proportionality", partial(_absolute_proportionality, election_cols=election_cols, party=party, mean=mean))
 
 def efficiency_gap(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
@@ -321,7 +324,8 @@ def efficiency_gap(election_cols: Iterable[str], mean: bool = False) -> Score:
         A score object with name `"efficiency_gap"`  and associated function that takes a partition
         and returns a PlanWideScoreValue for efficiency gap metric.
     """
-    return Score("efficiency_gap", partial(_efficiency_gap, election_cols=election_cols, mean=mean))
+    prefix = "mean_" if mean else ""
+    return Score(f"{prefix}efficiency_gap", partial(_efficiency_gap, election_cols=election_cols, mean=mean))
 
 def simplified_efficiency_gap(election_cols: Iterable[str], party: str, mean: bool = False) -> Score:
     """
@@ -339,7 +343,8 @@ def simplified_efficiency_gap(election_cols: Iterable[str], party: str, mean: bo
         A score object with name `"efficiency_gap"`  and associated function that takes a partition
         and returns a PlanWideScoreValue for efficiency gap metric.
     """
-    return Score("simplified_efficiency_gap", partial(_simplified_efficiency_gap, election_cols=election_cols, party=party, mean=mean))
+    prefix = "mean_" if mean else ""
+    return Score(f"{prefix}simplified_efficiency_gap", partial(_simplified_efficiency_gap, election_cols=election_cols, party=party, mean=mean))
 
 def mean_median(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
@@ -355,7 +360,8 @@ def mean_median(election_cols: Iterable[str], mean: bool = False) -> Score:
         A score object with name `"mean_median"` and associated function that takes a partition and
         returns a PlanWideScoreValue for the mean median metric.
     """
-    return Score("mean_median", partial(_mean_median, election_cols=election_cols, mean=mean))
+    prefix = "mean_" if mean else ""
+    return Score(f"{prefix}mean_median", partial(_mean_median, election_cols=election_cols, mean=mean))
 
 def partisan_bias(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
@@ -370,7 +376,8 @@ def partisan_bias(election_cols: Iterable[str], mean: bool = False) -> Score:
         A score object with name `"partisan_bias"` and associated function that takes a partition and
         returns a PlanWideScoreValue for partisan bias metric.
     """
-    return Score("partisan_bias", partial(_partisan_bias, election_cols=election_cols, mean=mean))
+    prefix = "mean_" if mean else ""
+    return Score(f"{prefix}partisan_bias", partial(_partisan_bias, election_cols=election_cols, mean=mean))
 
 def partisan_gini(election_cols: Iterable[str], mean: bool = False) -> Score:
     """
@@ -387,7 +394,8 @@ def partisan_gini(election_cols: Iterable[str], mean: bool = False) -> Score:
         A score object with name `"partisan_gini"` and associated function that takes a partition and
         returns a PlanWideScoreValue for the partisan gini metric.
     """
-    return Score("partisan_gini", partial(_partisan_gini, election_cols=election_cols, mean=mean))
+    prefix = "mean_" if mean else ""
+    return Score(f"{prefix}partisan_gini", partial(_partisan_gini, election_cols=election_cols, mean=mean))
 
 def eguia(election_cols: Iterable[str], party: str, graph: Graph, updaters: Mapping[str, Callable[[Partition], ScoreValue]],
           county_col: str, totpop_col: str = "population", mean: bool = False) -> Score:
@@ -415,7 +423,8 @@ def eguia(election_cols: Iterable[str], party: str, graph: Graph, updaters: Mapp
         a PlanWideScoreValue for the eguia metric. 
     """
     county_part = Partition(graph, county_col, updaters=updaters)
-    return Score("eguia", partial(_eguia, election_cols=election_cols, party=party, 
+    prefix = "mean_" if mean else ""
+    return Score(f"{prefix}eguia", partial(_eguia, election_cols=election_cols, party=party, 
                                   county_part=county_part, totpop_col=totpop_col, mean=mean))
 
 

--- a/tutorials/scoring_tutorial.ipynb
+++ b/tutorials/scoring_tutorial.ipynb
@@ -18,7 +18,19 @@
    "source": [
     "from gerrychain import Graph, Partition, Election\n",
     "from evaltools.scoring import *\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "import geopandas as gpd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "dba1f5f8-0ca5-4003-971d-1019d3ff3f49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
    ]
   },
   {
@@ -31,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "b9219c59-4f79-4ee0-b703-3b76f1341416",
    "metadata": {},
    "outputs": [
@@ -39,7 +51,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/gabe/Desktop/mggg/GerryChain/gerrychain/graph/adjacency.py:21: ShapelyDeprecationWarning: Setting custom attributes on geometry objects is deprecated, and will raise an AttributeError in Shapely 2.0\n",
+      "/Users/gabe/.local/share/virtualenvs/mggg-j24Bs5_X/lib/python3.9/site-packages/gerrychain/graph/adjacency.py:21: ShapelyDeprecationWarning: Setting custom attributes on geometry objects is deprecated, and will raise an AttributeError in Shapely 2.0\n",
       "  geometries[i].id = i\n"
      ]
     },
@@ -47,8 +59,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 20.6 s, sys: 1.12 s, total: 21.8 s\n",
-      "Wall time: 22.1 s\n"
+      "CPU times: user 17.3 s, sys: 1.19 s, total: 18.5 s\n",
+      "Wall time: 19.2 s\n"
      ]
     }
    ],
@@ -59,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "2472fff9-a5d0-4841-9ae3-ba4ecf3de32d",
    "metadata": {},
    "outputs": [],
@@ -85,18 +97,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "e7187565-ea2c-4790-b43b-7d0bf63bb2ae",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'TOTPOP20': <gerrychain.updaters.tally.Tally at 0x12912c480>,\n",
-       " 'VAP20': <gerrychain.updaters.tally.Tally at 0x12912c540>}"
+       "{'TOTPOP20': <gerrychain.updaters.tally.Tally at 0x123115600>,\n",
+       " 'VAP20': <gerrychain.updaters.tally.Tally at 0x123115200>}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -107,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "9f832170-d801-43fc-8302-9d39ec3fefc5",
    "metadata": {},
    "outputs": [],
@@ -135,17 +147,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "10e3c3c2-cc61-412a-a87a-1237eb45da19",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Score(name='Dem_seats', apply=functools.partial(<function _seats at 0x122b939d0>, election_cols=['PRES12', 'SEN12', 'GOV14', 'AG14', 'COMP14', 'PRES16', 'SEN16', 'GOV18', 'SEN18', 'AG18', 'COMP18'], party='Dem'))"
+       "Score(name='Dem_seats', apply=functools.partial(<function _seats at 0x11cfc5b80>, election_cols=['PRES12', 'SEN12', 'GOV14', 'AG14', 'COMP14', 'PRES16', 'SEN16', 'GOV18', 'SEN18', 'AG18', 'COMP18'], party='Dem', mean=False))"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -164,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "e0fa022f-b032-4116-8766-3e120907a0af",
    "metadata": {},
    "outputs": [
@@ -174,7 +186,7 @@
        "'Dem_seats'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -185,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "55e0d4c9-fa81-486f-b858-10d92634b7c7",
    "metadata": {},
    "outputs": [
@@ -205,7 +217,7 @@
        " 'COMP18': 8}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -224,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "1451edac-5641-4afd-990b-116ac5ac3250",
    "metadata": {},
    "outputs": [
@@ -244,13 +256,42 @@
        " 'COMP18': 0}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "seats(elections, \"Rep\").apply(partition)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ec0865f-2e0e-4f23-a315-3829f5d07306",
+   "metadata": {},
+   "source": [
+    "Moreover, we can pass `mean=True` to return the average of the score over all elections, rather than a dictionary:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "aabb0e46-d83d-4d71-92cc-e37a923b3845",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.1818181818181817"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "seats(elections, \"Rep\", mean=True).apply(partition)"
    ]
   },
   {
@@ -263,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "1150b377-f90c-4a1f-a875-62716ad1d3c0",
    "metadata": {},
    "outputs": [
@@ -283,7 +324,7 @@
        " 'COMP18': 0.05664447794898745}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -303,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "7f740c4d-4812-4d31-9250-3d912d1ff81e",
    "metadata": {},
    "outputs": [],
@@ -311,9 +352,9 @@
     "partisan_scores = [\n",
     "    seats(elections, \"Dem\"),\n",
     "    seats(elections, \"Rep\"),\n",
-    "    signed_proportionality(elections, \"Dem\"),\n",
-    "    absolute_proportionality(elections, \"Dem\"),\n",
-    "    efficiency_gap(elections),\n",
+    "    signed_proportionality(elections, \"Dem\", mean=True),\n",
+    "    absolute_proportionality(elections, \"Dem\", mean=True),\n",
+    "    efficiency_gap(elections, mean=True),\n",
     "    mean_median(elections),\n",
     "    partisan_bias(elections),\n",
     "    partisan_gini(elections),\n",
@@ -332,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "4759918a-795c-43f9-809e-01cf99b7b8fe",
    "metadata": {},
    "outputs": [
@@ -352,7 +393,7 @@
        " 'COMP18': 0.036168324606223434}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -360,6 +401,27 @@
    "source": [
     "partisan_dictionary = summarize(partition, partisan_scores)\n",
     "partisan_dictionary[\"mean_median\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "3c741bf9-7def-43d6-ba2e-d44e3784e2e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-0.02151975008383212"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "partisan_dictionary[\"mean_efficiency_gap\"]"
    ]
   },
   {
@@ -380,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "id": "2b8bd648-fa19-4d16-b4ae-771f52905753",
    "metadata": {},
    "outputs": [
@@ -413,7 +475,7 @@
        "  2: 110973}}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -427,7 +489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "id": "6529c95a-17ba-4be5-a13d-2b551f025505",
    "metadata": {},
    "outputs": [
@@ -452,7 +514,7 @@
        "  2: 0.1856474650446164}}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -478,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "id": "e7408521-644d-4846-8c2f-c96be4168737",
    "metadata": {},
    "outputs": [
@@ -495,7 +557,7 @@
        " 2: 82315}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -514,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "id": "cd52cd7d-e586-42ce-8328-af8543be1c7b",
    "metadata": {},
    "outputs": [
@@ -525,9 +587,9 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "Input \u001b[0;32mIn [16]\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mdemographic_tallies\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mWVAP20\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mapply\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpartition\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Input \u001b[0;32mIn [20]\u001b[0m, in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mdemographic_tallies\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mWVAP20\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mapply\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpartition\u001b[49m\u001b[43m)\u001b[49m\n",
       "File \u001b[0;32m~/Desktop/mggg/evaltools/evaltools/scoring/demographics.py:14\u001b[0m, in \u001b[0;36m_tally_pop\u001b[0;34m(part, pop_col)\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_tally_pop\u001b[39m(part: Partition, pop_col: \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m DistrictWideScoreValue:\n\u001b[0;32m---> 14\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mpart\u001b[49m\u001b[43m[\u001b[49m\u001b[43mpop_col\u001b[49m\u001b[43m]\u001b[49m\n",
-      "File \u001b[0;32m~/Desktop/mggg/GerryChain/gerrychain/partition/partition.py:135\u001b[0m, in \u001b[0;36mPartition.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    129\u001b[0m \u001b[38;5;124;03m\"\"\"Allows accessing the values of updaters computed for this\u001b[39;00m\n\u001b[1;32m    130\u001b[0m \u001b[38;5;124;03mPartition instance.\u001b[39;00m\n\u001b[1;32m    131\u001b[0m \n\u001b[1;32m    132\u001b[0m \u001b[38;5;124;03m:param key: Property to access.\u001b[39;00m\n\u001b[1;32m    133\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    134\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m key \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_cache:\n\u001b[0;32m--> 135\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_cache[key] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mupdaters\u001b[49m\u001b[43m[\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m]\u001b[49m(\u001b[38;5;28mself\u001b[39m)\n\u001b[1;32m    136\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_cache[key]\n",
+      "File \u001b[0;32m~/.local/share/virtualenvs/mggg-j24Bs5_X/lib/python3.9/site-packages/gerrychain/partition/partition.py:135\u001b[0m, in \u001b[0;36mPartition.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    129\u001b[0m \u001b[38;5;124;03m\"\"\"Allows accessing the values of updaters computed for this\u001b[39;00m\n\u001b[1;32m    130\u001b[0m \u001b[38;5;124;03mPartition instance.\u001b[39;00m\n\u001b[1;32m    131\u001b[0m \n\u001b[1;32m    132\u001b[0m \u001b[38;5;124;03m:param key: Property to access.\u001b[39;00m\n\u001b[1;32m    133\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    134\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m key \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_cache:\n\u001b[0;32m--> 135\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_cache[key] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mupdaters\u001b[49m\u001b[43m[\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m]\u001b[49m(\u001b[38;5;28mself\u001b[39m)\n\u001b[1;32m    136\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_cache[key]\n",
       "\u001b[0;31mKeyError\u001b[0m: 'WVAP20'"
      ]
     }
@@ -546,7 +608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "id": "efb2be2d-c295-4b2f-afd2-61d3257bbe76",
    "metadata": {},
    "outputs": [
@@ -556,7 +618,7 @@
        "{'BVAP20_gingles_districts': 1, 'HVAP20_gingles_districts': 0}"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -585,7 +647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
    "id": "0c43c6e2-e14c-49bd-af69-ee30ff5127b3",
    "metadata": {},
    "outputs": [
@@ -595,7 +657,7 @@
        "{'COUNTYFP20_splits': 5, 'COUNTYFP20_pieces': 12}"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -629,7 +691,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 23,
    "id": "98d64d3d-c391-4358-83cd-62f6a6e35532",
    "metadata": {},
    "outputs": [
@@ -658,39 +720,9 @@
        "  'SEN18': 2,\n",
        "  'AG18': 2,\n",
        "  'COMP18': 0},\n",
-       " 'signed_proportionality': {'PRES12': 0.934221741076855,\n",
-       "  'SEN12': 0.5589261140394672,\n",
-       "  'GOV14': 0.15384344415807183,\n",
-       "  'AG14': 1.3731431280054345,\n",
-       "  'COMP14': 0.9803379023942638,\n",
-       "  'PRES16': 0.878700025218448,\n",
-       "  'SEN16': 0.955579259583418,\n",
-       "  'GOV18': 0.47931709976328607,\n",
-       "  'SEN18': 0.5477734711790152,\n",
-       "  'AG18': 0.8111922064077586,\n",
-       "  'COMP18': 2.2265779117959488},\n",
-       " 'absolute_proportionality': {'PRES12': 0.934221741076855,\n",
-       "  'SEN12': 0.5589261140394672,\n",
-       "  'GOV14': 0.15384344415807183,\n",
-       "  'AG14': 1.3731431280054345,\n",
-       "  'COMP14': 0.9803379023942638,\n",
-       "  'PRES16': 0.878700025218448,\n",
-       "  'SEN16': 0.955579259583418,\n",
-       "  'GOV18': 0.47931709976328607,\n",
-       "  'SEN18': 0.5477734711790152,\n",
-       "  'AG18': 0.8111922064077586,\n",
-       "  'COMP18': 2.2265779117959488},\n",
-       " 'efficiency_gap': {'PRES12': -0.027366954931038075,\n",
-       "  'SEN12': -0.1112428189930485,\n",
-       "  'GOV14': -0.016952521996415275,\n",
-       "  'AG14': 0.0664089504401374,\n",
-       "  'COMP14': -0.03643474212627552,\n",
-       "  'PRES16': -0.04564932242915228,\n",
-       "  'SEN16': -0.02799189191120642,\n",
-       "  'GOV18': 0.09144998629410322,\n",
-       "  'SEN18': -0.12475998763996132,\n",
-       "  'AG18': -0.06082242557828398,\n",
-       "  'COMP18': 0.05664447794898745},\n",
+       " 'mean_signed_proportionality': 0.8999647548747244,\n",
+       " 'mean_absolute_proportionality': 0.8999647548747244,\n",
+       " 'mean_efficiency_gap': -0.02151975008383212,\n",
        " 'mean_median': {'PRES12': 0.02205704780736839,\n",
        "  'SEN12': 0.04184519796735442,\n",
        "  'GOV14': 0.0128224074264629,\n",
@@ -781,7 +813,7 @@
        " 'COUNTYFP20_pieces': 12}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
The following partisan scores now accept an optional `mean` boolean argument, which returns the average of the score over all elections:
- Seats
- Efficiency Gap
- Simplified Efficiency Gap
- Signed & Absolute Proportionality
- Mean Median
- Partisan Bias
- Partisan Gini
- Eguia

I also added a function (mainly in `demographics.py`) called `max_deviation()` which computes and returns the maximum population deviation of a plan.