### PR TITLE
Backport various funcs to maintain backwards compatibility with Python 3.8, etc.

### DIFF
--- a/evaltools/scoring/partisan.py
+++ b/evaltools/scoring/partisan.py
@@ -1,16 +1,16 @@
-from functools import cache
+from functools import lru_cache
 from gerrychain import Partition
 import numpy as np
 from typing import Iterable, Tuple
 from .score_types import *
 
-@cache
+@lru_cache(maxsize=None)
 def _election_results(part: Partition, election_cols: Tuple[str], party: str):
     return np.array([
                         np.array([part[e].percent(party, d) for d in sorted(part.parts.keys()) if d != -1])
                         for e in election_cols
                     ])
-@cache
+@lru_cache(maxsize=None)
 def _election_stability(part: Partition, election_cols: Tuple[str], party: str):
     return (_election_results(part, election_cols, party) > 0.5).sum(axis=0)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 requirements = [
     "pandas", "scipy", "networkx", "geopandas", "shapely", "matplotlib",
     "gerrychain", "sortedcontainers", "gurobipy", "jsonlines", "opencv-python",
-    "imageio", "us", "pydantic", "censusdata", "seaborn"
+    "imageio", "us", "pydantic", "censusdata", "seaborn", "maup"
 ]
 
 setup(


### PR DESCRIPTION
This is a draft PR. I do not have a working Python 3.8 or 3.7 install on my computer yet, so I do not know if this fixes everything.